### PR TITLE
Fixed crash when pressing BACK in lobby

### DIFF
--- a/Content.Client/UserInterface/HandsGui.cs
+++ b/Content.Client/UserInterface/HandsGui.cs
@@ -55,13 +55,13 @@ namespace Content.Client.UserInterface
 
         protected override void DrawContents()
         {
-            if (_playerManager?.LocalPlayer.ControlledEntity == null)
+            if (_playerManager == null || _playerManager.LocalPlayer == null)
             {
                 return;
             }
 
             IEntity entity = _playerManager.LocalPlayer.ControlledEntity;
-            if (!entity.TryGetComponent<IHandsComponent>(out var hands))
+            if (entity == null || !entity.TryGetComponent<IHandsComponent>(out var hands))
             {
                 return;
             }

--- a/Content.Client/UserInterface/HandsGui.cs
+++ b/Content.Client/UserInterface/HandsGui.cs
@@ -55,7 +55,7 @@ namespace Content.Client.UserInterface
 
         protected override void DrawContents()
         {
-            if (_playerManager == null || _playerManager.LocalPlayer == null)
+            if (_playerManager?.LocalPlayer == null)
             {
                 return;
             }


### PR DESCRIPTION
```
System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=Content.Client
  StackTrace:
   at Content.Client.UserInterface.HandsGui.DrawContents() in D:\spess\space-station-14-content\Content.Client\UserInterface\HandsGui.cs:line 58
   at SS14.Client.UserInterface.Controls.Control.Draw() in D:\spess\space-station-14-content\engine\SS14.Client\UserInterface\Controls\Control.cs:line 275
   at SS14.Client.UserInterface.UserInterfaceManager.Render(FrameEventArgs e) in D:\spess\space-station-14-content\engine\SS14.Client\UserInterface\UserInterfaceManager.cs:line 319
   at SS14.Client.GameController.Render(FrameEventArgs e) in D:\spess\space-station-14-content\engine\SS14.Client\GameController.cs:line 246
   at SS14.Client.GameController.Run() in D:\spess\space-station-14-content\engine\SS14.Client\GameController.cs:line 197
   at SS14.Client.Program.Main() in D:\spess\space-station-14-content\engine\SS14.Client\Program.cs:line 67
```

Apparently introduced by 5ee56a4c, maybe, perhaps, somehow?
LocalPlayer is null if you press BACK, causing this crash. However, I wonder why we're trying to draw HandsGui in the first place, since we're not actually going into the actual game.