### PR TITLE
Adds click parsing entity system

### DIFF
--- a/Content.Server/Content.Server.csproj
+++ b/Content.Server/Content.Server.csproj
@@ -91,7 +91,8 @@
     <Compile Include="GameObjects\Components\Weapon\Ranged\Projectile\ProjectileWeapon.cs" />
     <Compile Include="GameObjects\Components\Weapon\Ranged\RangedWeapon.cs" />
     <Compile Include="GameObjects\ContainerSlot.cs" />
-    <Compile Include="GameObjects\EntitySystems\InteractionSystem.cs" />
+    <Compile Include="GameObjects\EntitySystems\Click\ClickParser.cs" />
+    <Compile Include="GameObjects\EntitySystems\Click\InteractionSystem.cs" />
     <Compile Include="GameObjects\EntitySystems\PowerSystem.cs" />
     <Compile Include="Interfaces\GameObjects\Components\Items\IHandsComponent.cs" />
     <Compile Include="GameObjects\Components\GUI\ServerHandsComponent.cs" />
@@ -137,4 +138,5 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Content.Server/GameObjects/EntitySystems/Click/ClickParser.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/ClickParser.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using SS14.Server.Interfaces.Player;
+using SS14.Shared.GameObjects;
+using SS14.Shared.GameObjects.System;
+using SS14.Shared.Input;
+using SS14.Shared.Interfaces.GameObjects;
+using SS14.Shared.Interfaces.Network;
+using SS14.Shared.IoC;
+
+namespace Content.Server.GameObjects.EntitySystems
+{
+    /// <summary>
+    /// Catches clicks from the client and parses them to relevant entity systems
+    /// </summary>
+    public class ClickParserSystem : EntitySystem
+    {
+        /// <inheritdoc />
+        public override void RegisterMessageTypes()
+        {
+            base.RegisterMessageTypes();
+
+            RegisterMessageType<ClickEventMessage>();
+        }
+
+        /// <summary>
+        /// Grab click events sent from the client input system
+        /// </summary>
+        /// <param name="channel"></param>
+        /// <param name="message"></param>
+        public override void HandleNetMessage(INetChannel channel, EntitySystemMessage message)
+        {
+            base.HandleNetMessage(channel, message);
+
+            var playerMan = IoCManager.Resolve<IPlayerManager>();
+            var session = playerMan.GetSessionByChannel(channel);
+            var playerentity = session.AttachedEntity;
+
+            if (playerentity == null)
+                return;
+
+            switch (message)
+            {
+                case ClickEventMessage msg:
+                    ParseClickMessage(msg, playerentity);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Parse click to the relevant entity system
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="player"></param>
+        private void ParseClickMessage(ClickEventMessage message, IEntity player)
+        {
+            switch (message.Click)
+            {
+                case ClickType.Left:
+                    EntitySystemManager.GetEntitySystem<InteractionSystem>().UserInteraction(message, player);
+                    break;
+                case (ClickType.Left | ClickType.Shift):
+                    //Examine system
+                    break;
+                case ClickType.Right:
+                    //Verb System
+                    break;
+            }
+        }
+    }
+}

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -6,9 +6,6 @@ using SS14.Shared.Interfaces.GameObjects;
 using System.Collections.Generic;
 using System.Linq;
 using SS14.Shared.Input;
-using SS14.Shared.Interfaces.Network;
-using SS14.Shared.IoC;
-using SS14.Server.Interfaces.Player;
 using SS14.Shared.Log;
 using SS14.Shared.Map;
 using SS14.Server.GameObjects;
@@ -92,40 +89,8 @@ namespace Content.Server.GameObjects.EntitySystems
         private const float INTERACTION_RANGE = 2;
         private const float INTERACTION_RANGE_SQUARED = INTERACTION_RANGE * INTERACTION_RANGE;
 
-        /// <inheritdoc />
-        public override void RegisterMessageTypes()
+        public void UserInteraction(ClickEventMessage msg, IEntity player)
         {
-            base.RegisterMessageTypes();
-
-            RegisterMessageType<ClickEventMessage>();
-        }
-
-        //Grab click events sent from the client input system
-        public override void HandleNetMessage(INetChannel channel, EntitySystemMessage message)
-        {
-            base.HandleNetMessage(channel, message);
-
-            var playerMan = IoCManager.Resolve<IPlayerManager>();
-            var session = playerMan.GetSessionByChannel(channel);
-            var playerentity = session.AttachedEntity;
-
-            if (playerentity == null)
-                return;
-
-            switch (message)
-            {
-                case ClickEventMessage msg:
-                    UserInteraction(msg, playerentity);
-                    break;
-            }
-        }
-
-        private void UserInteraction(ClickEventMessage msg, IEntity player)
-        {
-            //Verify click type
-            if (msg.Click != ClickType.Left)
-                return;
-
             //Get entity clicked upon from UID if valid UID, if not assume no entity clicked upon and null
             IEntity attacked = null;
             if (msg.Uid.IsValid())
@@ -227,7 +192,7 @@ namespace Content.Server.GameObjects.EntitySystems
         /// <param name="user"></param>
         /// <param name="weapon"></param>
         /// <param name="clicklocation"></param>
-        private void InteractAfterattack(IEntity user, IEntity weapon, LocalCoordinates clicklocation)
+        public static void InteractAfterattack(IEntity user, IEntity weapon, LocalCoordinates clicklocation)
         {
             List<IAfterAttack> afterattacks = weapon.GetComponents<IAfterAttack>().ToList();
 


### PR DESCRIPTION
Instead of every entity system receiving the message and deciding if it individually wants the message, and verifying player information. The click parser system receives the message and parses which system to send it to based on clicktype and sends it.

Fixes #54 