### PR TITLE
Fixes server crashing when attempting to drop an empty hand's contained entity.

### DIFF
--- a/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
@@ -166,7 +166,7 @@ namespace Content.Server.GameObjects
         public bool CanDrop(string slot)
         {
             var inventorySlot = hands[slot];
-            return (inventorySlot.ContainedEntity != null) && inventorySlot.CanRemove(inventorySlot.ContainedEntity);
+            return inventorySlot.CanRemove(inventorySlot.ContainedEntity);
         }
 
         public void AddHand(string index)

--- a/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
@@ -166,7 +166,7 @@ namespace Content.Server.GameObjects
         public bool CanDrop(string slot)
         {
             var inventorySlot = hands[slot];
-            return inventorySlot.CanRemove(inventorySlot.ContainedEntity);
+            return (inventorySlot.ContainedEntity != null) && inventorySlot.CanRemove(inventorySlot.ContainedEntity);
         }
 
         public void AddHand(string index)

--- a/Content.Server/GameObjects/ContainerSlot.cs
+++ b/Content.Server/GameObjects/ContainerSlot.cs
@@ -31,7 +31,7 @@ namespace Content.Server.GameObjects
         /// <inheritdoc />
         public override bool Contains(IEntity contained)
         {
-            if (contained == ContainedEntity)
+            if (contained != null && contained == ContainedEntity)
                 return true;
             return false;
         }


### PR DESCRIPTION
Tested clean & build. No more crashing when dropping an empty hand's supposed contained item, and dropping existing contained items still works.