### PR TITLE
Fixes seeing default scene text on opening container for the first time

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
@@ -119,6 +119,7 @@ namespace Content.Server.GameObjects
         bool IUse.UseEntity(IEntity user)
         {
             SendNetworkMessage(new OpenStorageUIMessage());
+            UpdateClientInventory();
             return false;
         }
 


### PR DESCRIPTION
Fixes the annoying "0/0 storage capacity" text you get instead of the real values when opening a container for the first time, because the server didn't update the client with the contents of the container when asking it to open the window.