### PR TITLE
Destructible component rework

### DIFF
--- a/Content.Server/EntryPoint.cs
+++ b/Content.Server/EntryPoint.cs
@@ -45,6 +45,7 @@ using Content.Shared.GameObjects.Components.Mobs;
 using Content.Shared.Interfaces;
 using SS14.Server.Interfaces.ServerStatus;
 using SS14.Shared.Timing;
+using Content.Server.GameObjects.Components.Destructible;
 
 namespace Content.Server
 {

--- a/Resources/Maps/stationstation.yml
+++ b/Resources/Maps/stationstation.yml
@@ -34,19 +34,19 @@ entities:
     pos: 4.5,-0.5
     rot: -1.570796 rad
     type: Transform
-- type: wall
+- type: girder
   components:
   - grid: 0
     pos: -7,6
     rot: -1.570796 rad
     type: Transform
-- type: wall
+- type: girder
   components:
   - grid: 0
     pos: -7,-4
     rot: -1.570796 rad
     type: Transform
-- type: wall
+- type: girder
   components:
   - grid: 0
     pos: -7,-3
@@ -178,13 +178,13 @@ entities:
     pos: -7,-6
     rot: -1.570796 rad
     type: Transform
-- type: wall
+- type: girder
   components:
   - grid: 0
     pos: -4,-6
     rot: -1.570796 rad
     type: Transform
-- type: wall
+- type: girder
   components:
   - grid: 0
     pos: -4,-5

--- a/Resources/Prototypes/Entities/girder.yml
+++ b/Resources/Prototypes/Entities/girder.yml
@@ -1,0 +1,22 @@
+- type: entity
+  id: girder
+  name: Girder
+  components:
+  - type: Clickable
+  - type: Sprite
+    texture: Buildings/wall_girder.png
+  - type: Icon
+    texture: Buildings/wall_girder.png
+
+  - type: BoundingBox
+  - type: Collidable
+  - type: Damageable
+  - type: Destructible
+    thresholdvalue: 50
+    spawnondestroy: SteelSheet1
+  - type: SnapGrid
+    offset: Edge
+
+  placement:
+    snap:
+    - Wall

--- a/Resources/Prototypes/Entities/walls.yml
+++ b/Resources/Prototypes/Entities/walls.yml
@@ -15,6 +15,10 @@
 
   - type: BoundingBox
   - type: Collidable
+  - type: Damageable
+  - type: Destructible
+    thresholdvalue: 100
+    spawnondestroy: girder
   - type: Occluder
     sizeX: 32
     sizeY: 32


### PR DESCRIPTION
* Walls are destructible now
* Added girders that spawn after wall’s destruction
* Girders drop metal sheet on destruction

Content.Server posts this in console:
```
[ERRO] runtime: Caught exception in GameLoop Tick: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
  at System.Collections.Generic.List`1+Enumerator[T].MoveNextRare () [0x00013] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/List.cs:1164 
  at System.Collections.Generic.List`1+Enumerator[T].MoveNext () [0x0004a] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/List.cs:1157 
  at System.Linq.Enumerable+WhereListIterator`1[TSource].MoveNext () [0x0004e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/Where.cs:348 
  at System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].MoveNext () [0x0004e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/Where.cs:140 
  at SS14.Server.GameObjects.EntitySystems.PhysicsSystem.Update (System.Single frameTime) [0x00041] in space-station-14-content/engine/SS14.Server/GameObjects/EntitySystems/PhysicsSystem.cs:33 
  at SS14.Shared.GameObjects.EntitySystemManager.Update (System.Single frameTime) [0x0001e] in space-station-14-content/engine/SS14.Shared/GameObjects/EntitySystemManager.cs:146 
  at SS14.Shared.GameObjects.EntityManager.Update (System.Single frameTime) [0x00008] in space-station-14-content/engine/SS14.Shared/GameObjects/EntityManager.cs:95 
  at SS14.Server.BaseServer.Update (System.Single frameTime) [0x0004c] in space-station-14-content/engine/SS14.Server/BaseServer.cs:325 
  at SS14.Server.BaseServer.<MainLoop>b__27_0 (System.Object sender, SS14.Shared.Timing.FrameEventArgs args) [0x00000] in space-station-14-content/engine/SS14.Server/BaseServer.cs:238 
  at SS14.Shared.Timing.GameLoop.Run () [0x001d2] in space-station-14-content/engine/SS14.Shared/Timing/GameLoop.cs:124 
```
but it works regardless.